### PR TITLE
NPCS cannot open any locked doors

### DIFF
--- a/0-SphereIICore/Scripts/Entities/EntityAliveEnemySDX.cs
+++ b/0-SphereIICore/Scripts/Entities/EntityAliveEnemySDX.cs
@@ -204,7 +204,7 @@ public class EntityAliveEnemySDX : EntityEnemy
                     TileEntitySecureDoor tileEntitySecureDoor = GameManager.Instance.World.GetTileEntity(0, blockPos) as TileEntitySecureDoor;
                     if (tileEntitySecureDoor != null)
                     {
-                        if (tileEntitySecureDoor.IsLocked() && tileEntitySecureDoor.GetOwner() == "")
+                        if (tileEntitySecureDoor.IsLocked())
                             canOpenDoor = false;
                     }
                     //TileEntityPowered poweredDoor = GameManager.Instance.World.GetTileEntity(0, blockPos) as TileEntityPowered;

--- a/0-SphereIICore/Scripts/Entities/EntityAliveSDX.cs
+++ b/0-SphereIICore/Scripts/Entities/EntityAliveSDX.cs
@@ -563,7 +563,7 @@ public class EntityAliveSDX : EntityNPC
                     TileEntitySecureDoor tileEntitySecureDoor = GameManager.Instance.World.GetTileEntity(0, blockPos) as TileEntitySecureDoor;
                     if (tileEntitySecureDoor != null)
                     {
-                        if (tileEntitySecureDoor.IsLocked() && tileEntitySecureDoor.GetOwner() == "")
+                        if (tileEntitySecureDoor.IsLocked())
                             canOpenDoor = false;
                     }
                     //TileEntityPowered poweredDoor = GameManager.Instance.World.GetTileEntity(0, blockPos) as TileEntityPowered;


### PR DESCRIPTION
Prior to these changes, the NPCs could open any locked doors with no "owner." (Presumably this meant locked POI doors.) These changes mean that NPCs cannot open *any* locked doors, including doors locked by their player "owners." (This is intentional.) They will still open and close unlocked doors, as they did before.