### PR TITLE
Entity targeting should use leader/owner

### DIFF
--- a/0-SphereIICore/Config/blocks.xml
+++ b/0-SphereIICore/Config/blocks.xml
@@ -105,7 +105,7 @@
         <!-- Turn on or off Maslow for NPCs -->
         <property name="AnimalMaslow" value="true" />
         <!-- Turn on or off maslow for animals. -->
-        <property name="HumanTags"  value="human,bandit,survivor,npc,trader" />
+        <property name="HumanTags"  value="human,bandit,survivor,npc,trader,deployed" />
         <!-- Tags that translate that the entity is alive and has a brain -->
 
       </property>

--- a/0-SphereIICore/Harmony/EAI/EAITarget.cs
+++ b/0-SphereIICore/Harmony/EAI/EAITarget.cs
@@ -19,6 +19,11 @@ class SphereII_EAITarget_Tweaks
 
         public static bool Postfix(bool __result, EAITarget __instance, EntityAlive _e)
         {
+            // If the original method already determined this isn't a valid target, don't bother
+            if (!__result)
+                return __result;
+
+            // Only "humans" should use faction-based targeting
             if (!EntityUtilities.IsHuman(__instance.theEntity.entityId))
                 return __result;
 
@@ -29,54 +34,63 @@ class SphereII_EAITarget_Tweaks
             //if (__instance.theEntity.IsSleeping)
             //    return __result;
 
-            // The base class sees this as a valid target.
-            if (__result)
+            // if the attack cool down is applied, don't set a new target.
+            if (__instance.theEntity.Buffs.HasBuff("buffAttackCoolDown"))
+                return false;
+            
+            var instanceTargetingEntity = GetTargetingEntity(__instance.theEntity);
+            var eTargetingEntity = GetTargetingEntity(_e);
+
+            // Check if the entities have the same ID. This can happen if one or both entities
+            // have a leader or owner, and we're using it for targeting purposes.
+            if (instanceTargetingEntity.entityId == eTargetingEntity.entityId)
+                return false;
+
+            // same faction
+            if (instanceTargetingEntity.factionId == eTargetingEntity.factionId)
+                return false;
+
+            // We have some complicated checks here, since this method gets called by 3 different target methods.
+            FactionManager.Relationship myRelationship = FactionManager.Instance.GetRelationshipTier(
+                instanceTargetingEntity,
+                eTargetingEntity);
+
+            // Debug.Log("Checking Relationship: " + myRelationship.ToString() + " " + __instance.theEntity.EntityName + " and " + _e.EntityName);
+            switch (myRelationship)
             {
-                // same faction
-                if (__instance.theEntity.factionId == _e.factionId)
+                case FactionManager.Relationship.Hate:
+                    return true;
+
+                case FactionManager.Relationship.Dislike:
+                case FactionManager.Relationship.Neutral:
+                    // If you don't like them, or are more or less neutral to them, 
+                    // know the difference between an aggressive hit, or just a regular scan of entities.
+                    if (__instance is EAISetNearestEntityAsTarget)
+                        return false; // they aren't an enemy to kill right off
+                    if (__instance is EAISetAsTargetIfHurt)
+                        return true;  // They suck! They hurt you. Get them!
                     return false;
-
-                // Check if its a leader.
-                Entity myLeader = EntityUtilities.GetLeaderOrOwner(__instance.theEntity.entityId);
-                if (myLeader)
-                {
-                    if (_e.entityId == myLeader.entityId)
-                        return false;
-                }
-
-                // if the attack cool down is applied, don't set a new target for 30 seconds.
-                if (__instance.theEntity.Buffs.HasBuff("buffAttackCoolDown"))
+                case FactionManager.Relationship.Love:
+                case FactionManager.Relationship.Leader:
                     return false;
-
-                // We have some complicated checks here, since this method gets called by 3 different target methods.
-                FactionManager.Relationship myRelationship = FactionManager.Instance.GetRelationshipTier(__instance.theEntity, _e);
-                 //Debug.Log("Checking Relationship: " + myRelationship.ToString() + " " + __instance.theEntity.EntityName + " and " + _e.EntityName);
-                switch (myRelationship)
-                {
-                    case FactionManager.Relationship.Hate:
-                        return true;
-
-                    case FactionManager.Relationship.Dislike:
-                    case FactionManager.Relationship.Neutral:
-                        // If you don't like them, or are more or less neutral to them, 
-                        // know the difference between an aggressive hit, or just a regular scan of entities.
-                        if (__instance is EAISetNearestEntityAsTarget)
-                            return false; // they aren't an enemy to kill right off
-                        if (__instance is EAISetAsTargetIfHurt)
-                            return true;  // They suck! They hurt you. Get them!
-                        return false;
-                    case FactionManager.Relationship.Love:
-                    case FactionManager.Relationship.Leader:
-                        return false;
-                    default:
-                        return false;
-                }
+                default:
+                    return false;
             }
-            return __result;
         }
     }
 
-
+    /// <summary>
+    /// Gets the entity that should be used for targeting calculations.
+    /// If the given entity has a leader or owner, that will be used.
+    /// Otherwise, the entity itself will be used.
+    /// </summary>
+    /// <param name="entity">The entity to check.</param>
+    /// <returns>The entity that should be used for targeting.</returns>
+    private static EntityAlive GetTargetingEntity(EntityAlive entity)
+    {
+        var leader = EntityUtilities.GetLeaderOrOwner(entity.entityId) as EntityAlive;
+        return leader == null ? entity : leader;
+    }
 
 }
 


### PR DESCRIPTION
This changes the Harmony postfix of `EAITarget.check` so that the entity used for targeting purposes is the entity's leader or owner, if any exists.

This applies to both the entity doing the targeting, and the entity being targeted.

Any other code changes are just refactoring to make the code cleaner and/or avoid unnecessary CPU cycles; they should not affect behavior.

Additionally, the "deployed" tag is added to the "HumanTags" in the config feature block. This will make deployed entities (junk sledge, junk turret, junk drone) use the same targeting check, so they no longer target NPCs hired by the player.