### PR TITLE
Removed override of SetSleeper

### DIFF
--- a/0-SphereIICore/Scripts/Entities/EntityAliveSDX.cs
+++ b/0-SphereIICore/Scripts/Entities/EntityAliveSDX.cs
@@ -186,14 +186,6 @@ public class EntityAliveSDX : EntityNPC
         return 0.25f;
     }
 
-    public override void SetSleeper()
-    {
-        // if configured as a sleeper, this should wake them up
-        if (isAlwaysAwake)
-            return;
-        base.SetSleeper();
-    }
-
     /// <summary>
     /// Overrides EntityAlive.OnAddedToWorld().
     /// When entities are spawned into sleeper volumes, which happens in SleeperVolume.Spawn(),


### PR DESCRIPTION
If the base SetSleeper method is not called, and the entity is spawned from a sleeper volume, the entity will continuously respawn in its original location. Removing the override solved this issue, and did not interfere with the entity spawning in awake.