### PR TITLE
#4: Add read-only cvars representing faction relationships

### DIFF
--- a/0-SphereIICore/Config/blocks.xml
+++ b/0-SphereIICore/Config/blocks.xml
@@ -107,7 +107,8 @@
         <!-- Turn on or off maslow for animals. -->
         <property name="HumanTags"  value="human,bandit,survivor,npc,trader,deployed" />
         <!-- Tags that translate that the entity is alive and has a brain -->
-
+        <property name="FactionRelationshipCVars" value="false" />
+        <!-- Enables the addition of faction relationship cvars (see FactionRelationshipCVars.cs)  -->
       </property>
 
       <!-- Allow themed settings to be applied: See Harmony/Atmosphere/-->

--- a/0-SphereIICore/Harmony/Faction/FactionRelationshipCVars.cs
+++ b/0-SphereIICore/Harmony/Faction/FactionRelationshipCVars.cs
@@ -1,0 +1,70 @@
+using HarmonyLib;
+using System;
+using System.Reflection;
+using UnityEngine;
+
+/// <summary>
+/// This class will add read-only custom variables (cvars), that represent the player's
+/// relationship with each non-player faction. Those cvars can be used any place that a cvar can
+/// normally be read: effect requirements, localization, XUi player stats entries, etc.
+/// 
+/// The name of the cvar will be "_relationship[faction name]" where "[faction name]" is the name
+/// of the faction, as defined in the faction's "name" attribute in <c>npc.xml</c>.
+/// 
+/// It must be enabled in the <c>FactionRelationshipCVars</c> property, under
+/// <c>AdvancedNPCFeatures</c> in <c>ConfigFeatureBlock</c>.
+/// 
+/// NOTE: If the relationship is exactly zero, the cvar will not be set. This is because 7D2D
+/// treats setting any cvar value to zero as removing the cvar. This can happen if the faction
+/// relationship is initially "Hate," or is reduced to zero later. The cvar will be set again if
+/// the relationship becomes anything other than zero. Trying to read the value of a non-existent
+/// cvar will result in a value of zero anyway, so this should not affect any uses of the cvar.
+/// </summary>
+public class FactionRelationshipCVars
+{
+    [HarmonyPatch(typeof(EntityPlayerLocal), "Update")]
+    public class FactionRelationshipCVars_EntityPlayerLocal_Update
+    {
+        private const string CVarPrefix = "_relationship";
+        private const string AdvFeatureClass = "AdvancedNPCFeatures";
+        private const string Feature = "FactionRelationshipCVars";
+
+        private static bool enabled = false;
+        private static Faction[] factions = null;
+        private static bool initialized = false;
+
+        private static void Initialize()
+        {
+            initialized = true;
+            enabled = Configuration.CheckFeatureStatus(AdvFeatureClass, Feature);
+            if (!enabled)
+                return;
+
+            // Unfortunately, the Factions field is private
+            var factionsInfo = typeof(FactionManager).GetField(
+                "Factions",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+
+            if (factionsInfo != null)
+                factions = (Faction[]) factionsInfo.GetValue(FactionManager.Instance);
+        }
+
+        public static void Postfix(EntityPlayerLocal __instance)
+        {
+            if (!initialized)
+                Initialize();
+            
+            if (!enabled || factions == null)
+                return;
+
+            for (var i = 0; i < factions.Length; i++)
+            {
+                if (factions[i] == null || factions[i].IsPlayerFaction)
+                    continue;
+                
+                var relationship = factions[i].GetRelationship(__instance.factionId);
+                __instance.SetCVar($"{CVarPrefix}{factions[i].Name}", relationship);
+            }
+        }
+    }
+}


### PR DESCRIPTION
These cvars will only be added if the setting in the config feature block is enabled.