### PR TITLE
Bump version number to distinguish latest code changes

### DIFF
--- a/0-SphereIICore/ModInfo.xml
+++ b/0-SphereIICore/ModInfo.xml
@@ -4,7 +4,7 @@
     <Name value="0-SphereIICore" />
     <Description value="SphereII's Core Class Mod ( Required )" />
     <Author value="sphereii" />
-    <Version value="19.3.1.14" />
+    <Version value="19.3.1.15" />
     <Website value="" />
   </ModInfo>
   <DMT Hash="a2f2c62aaafdc453020902f7b06d7c7e">


### PR DESCRIPTION
Without the bump in version number, I won't be able to specify which version of Core is required.